### PR TITLE
Feat: 회원 재료 등록 기능 추가 (#4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,15 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+//    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/clearthefridge/controller/UserIngredientController.java
+++ b/src/main/java/com/example/clearthefridge/controller/UserIngredientController.java
@@ -1,0 +1,27 @@
+package com.example.clearthefridge.controller;
+
+import com.example.clearthefridge.dto.Ingredient.AddRequestDto;
+import com.example.clearthefridge.service.UserIngredientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/ingredient")
+public class UserIngredientController {
+
+    private final UserIngredientService userIngredientService;
+
+    //냉장고 속 재료 추가
+    @PostMapping("")
+    public ResponseEntity<String> addIngredient(@RequestBody AddRequestDto ingredients) {
+        userIngredientService.addIngredient(ingredients);
+        return ResponseEntity.ok("재료 등록 성공");
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/example/clearthefridge/dto/Ingredient/AddRequestDto.java
+++ b/src/main/java/com/example/clearthefridge/dto/Ingredient/AddRequestDto.java
@@ -1,0 +1,54 @@
+package com.example.clearthefridge.dto.Ingredient;
+
+import com.example.clearthefridge.entity.Ingredient;
+import com.example.clearthefridge.entity.User;
+import com.example.clearthefridge.entity.UserIngredient;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddRequestDto {
+
+    private Long userId;
+
+    @NotNull
+    private List<IngredientDto> ingredientList;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class IngredientDto {
+        @NotBlank(message = "이름은 필수 항목 입니다.")
+        private String name;
+
+        private String amount;
+
+        private String unit;
+
+        public UserIngredient toEntity(User user, Ingredient ingredient) {
+            LocalDateTime now = LocalDateTime.now();
+            Integer recommendedDays = ingredient.getLifeDays();
+            LocalDateTime expiry = now.plusDays(recommendedDays);
+
+            return UserIngredient.builder()
+                    .user(user)
+                    .ingredient(ingredient)
+                    .amount(this.amount)
+                    .unit(this.unit)
+                    .createdAt(now)
+                    .expiryDate(expiry)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/clearthefridge/entity/Ingredient.java
+++ b/src/main/java/com/example/clearthefridge/entity/Ingredient.java
@@ -2,6 +2,7 @@ package com.example.clearthefridge.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,11 +11,16 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class Ingredient {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    //재료 이름
     private String name;
+
+    //소비 권장 기한
+    private Integer lifeDays;
 }

--- a/src/main/java/com/example/clearthefridge/entity/User.java
+++ b/src/main/java/com/example/clearthefridge/entity/User.java
@@ -2,6 +2,7 @@ package com.example.clearthefridge.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class User {
 
     @Id

--- a/src/main/java/com/example/clearthefridge/entity/UserIngredient.java
+++ b/src/main/java/com/example/clearthefridge/entity/UserIngredient.java
@@ -1,8 +1,10 @@
 package com.example.clearthefridge.entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +14,7 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class UserIngredient {
 
     @Id
@@ -24,6 +27,18 @@ public class UserIngredient {
     @ManyToOne
     private Ingredient ingredient;
 
+    //재료 단위 ex g, ml,
+    private String unit;
+
+    //재료 수량
     private String amount;
+
+    //유통기한 만료일
     private LocalDateTime expiryDate;
+
+    //재료 등록일
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+
 }

--- a/src/main/java/com/example/clearthefridge/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/clearthefridge/global/exception/ErrorCode.java
@@ -21,7 +21,9 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
 
     // Error code 500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+
+    NOT_FOUNT_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/clearthefridge/repository/IngredientRepository.java
+++ b/src/main/java/com/example/clearthefridge/repository/IngredientRepository.java
@@ -1,0 +1,16 @@
+package com.example.clearthefridge.repository;
+
+
+import com.example.clearthefridge.entity.Ingredient;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+
+    Optional<Ingredient> findByName(String name);
+}

--- a/src/main/java/com/example/clearthefridge/repository/UserIngredientRepository.java
+++ b/src/main/java/com/example/clearthefridge/repository/UserIngredientRepository.java
@@ -1,0 +1,10 @@
+package com.example.clearthefridge.repository;
+
+import com.example.clearthefridge.entity.UserIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+
+public interface UserIngredientRepository extends JpaRepository<UserIngredient, Long> {
+
+}

--- a/src/main/java/com/example/clearthefridge/repository/UserRepository.java
+++ b/src/main/java/com/example/clearthefridge/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.clearthefridge.repository;
+
+import com.example.clearthefridge.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/clearthefridge/service/IngredientService.java
+++ b/src/main/java/com/example/clearthefridge/service/IngredientService.java
@@ -1,0 +1,7 @@
+package com.example.clearthefridge.service;
+
+
+
+public interface IngredientService {
+
+}

--- a/src/main/java/com/example/clearthefridge/service/UserIngredientService.java
+++ b/src/main/java/com/example/clearthefridge/service/UserIngredientService.java
@@ -1,0 +1,11 @@
+package com.example.clearthefridge.service;
+
+import com.example.clearthefridge.dto.Ingredient.AddRequestDto;
+
+public interface UserIngredientService {
+
+    void addIngredient(AddRequestDto ingredient);
+
+
+
+}

--- a/src/main/java/com/example/clearthefridge/service/impl/IngredientServiceImpl.java
+++ b/src/main/java/com/example/clearthefridge/service/impl/IngredientServiceImpl.java
@@ -1,0 +1,11 @@
+package com.example.clearthefridge.service.impl;
+
+import com.example.clearthefridge.service.IngredientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IngredientServiceImpl implements IngredientService {
+
+}

--- a/src/main/java/com/example/clearthefridge/service/impl/UserIngredientServiceImpl.java
+++ b/src/main/java/com/example/clearthefridge/service/impl/UserIngredientServiceImpl.java
@@ -1,0 +1,50 @@
+package com.example.clearthefridge.service.impl;
+
+
+import com.example.clearthefridge.dto.Ingredient.AddRequestDto;
+import com.example.clearthefridge.dto.Ingredient.GetResponseDto;
+import com.example.clearthefridge.entity.Ingredient;
+import com.example.clearthefridge.entity.User;
+import com.example.clearthefridge.entity.UserIngredient;
+import com.example.clearthefridge.global.exception.CustomException;
+import com.example.clearthefridge.global.exception.ErrorCode;
+import com.example.clearthefridge.repository.IngredientRepository;
+import com.example.clearthefridge.repository.UserIngredientRepository;
+import com.example.clearthefridge.repository.UserRepository;
+import com.example.clearthefridge.service.UserIngredientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserIngredientServiceImpl implements UserIngredientService {
+
+    private final UserIngredientRepository userIngredientRepository;
+    private final IngredientRepository ingredientRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void addIngredient(AddRequestDto ingredients) {
+        User user = userRepository.findById(ingredients.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_USER));
+
+        for (AddRequestDto.IngredientDto dto : ingredients.getIngredientList()) {
+            Ingredient ingredient = ingredientRepository.findByName(dto.getName())
+                    .orElseGet(() -> {   //이전에 등록 되어 있지 않은 재료들 저장
+                        Ingredient newIngredient = Ingredient.builder()
+                                .name(dto.getName())
+                                .lifeDays(7)
+                                .build();
+                        return ingredientRepository.save(newIngredient);
+                    });
+            UserIngredient userIngredient = dto.toEntity(user, ingredient);
+            userIngredientRepository.save(userIngredient);
+        }
+    }
+}

--- a/src/test/java/com/example/clearthefridge/service/impl/UserIngredientServiceImplTest.java
+++ b/src/test/java/com/example/clearthefridge/service/impl/UserIngredientServiceImplTest.java
@@ -1,0 +1,151 @@
+package com.example.clearthefridge.service.impl;
+
+import com.example.clearthefridge.dto.Ingredient.AddRequestDto;
+import com.example.clearthefridge.dto.Ingredient.AddRequestDto.IngredientDto;
+import com.example.clearthefridge.entity.Ingredient;
+import com.example.clearthefridge.entity.User;
+import com.example.clearthefridge.entity.UserIngredient;
+import com.example.clearthefridge.global.exception.CustomException;
+import com.example.clearthefridge.global.exception.ErrorCode;
+import com.example.clearthefridge.repository.IngredientRepository;
+import com.example.clearthefridge.repository.UserIngredientRepository;
+import com.example.clearthefridge.repository.UserRepository;
+import com.example.clearthefridge.service.UserIngredientService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class UserIngredientServiceImplTest {
+
+    @Autowired
+    private UserIngredientService userIngredientService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private IngredientRepository ingredientRepository;
+
+    @Autowired
+    private UserIngredientRepository userIngredientRepository;
+
+    private User savedUser;
+
+    @BeforeEach
+    void setup() {
+        userIngredientRepository.deleteAll();
+        ingredientRepository.deleteAll();
+        userRepository.deleteAll();
+
+        savedUser = User.builder()
+                .username("testUser")
+                .build();
+        savedUser = userRepository.save(savedUser);
+    }
+
+    @Test
+    void 재료_추가_사용자가_없는_경우() {
+        userRepository.deleteAll();
+
+        IngredientDto dto = IngredientDto.builder()
+                .name("토마토")
+                .amount("2")
+                .unit("개")
+                .build();
+        AddRequestDto request = AddRequestDto.builder()
+                .userId(savedUser.getId())
+                .ingredientList(Collections.singletonList(dto))
+                .build();
+
+        assertThatThrownBy(() -> userIngredientService.addIngredient(request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NOT_FOUNT_USER);
+
+        assertThat(userIngredientRepository.count()).isZero();
+    }
+
+    @Test
+    void 새로운_재료_추가_성공() {
+        // 기존에 "토마토"가 재료 테이블에 없는 경우
+        assertThat(ingredientRepository.findByName("토마토")).isEmpty();
+
+        IngredientDto dto = IngredientDto.builder()
+                .name("토마토")
+                .amount("2")
+                .unit("개")
+                .build();
+        AddRequestDto request = AddRequestDto.builder()
+                .userId(savedUser.getId())
+                .ingredientList(Collections.singletonList(dto))
+                .build();
+
+        userIngredientService.addIngredient(request);
+
+        List<Ingredient> ingredients = ingredientRepository.findAll();
+        assertThat(ingredients).hasSize(1);
+        Ingredient ing = ingredients.get(0);
+        assertThat(ing.getName()).isEqualTo("토마토");
+        assertThat(ing.getLifeDays()).isEqualTo(7);
+
+        List<UserIngredient> userIngredients = userIngredientRepository.findAll();
+        assertThat(userIngredients).hasSize(1);
+        UserIngredient ui = userIngredients.get(0);
+        assertThat(ui.getUser().getId()).isEqualTo(savedUser.getId());
+        assertThat(ui.getIngredient().getId()).isEqualTo(ing.getId());
+        assertThat(ui.getAmount()).isEqualTo("2");
+        assertThat(ui.getUnit()).isEqualTo("개");
+        assertThat(ui.getCreatedAt()).isNotNull();
+        assertThat(ui.getExpiryDate()).isNotNull();
+    }
+
+    @Test
+    void 여러_재료_추가_성공() {
+        Ingredient existing = Ingredient.builder()
+                .name("양파")
+                .lifeDays(10)
+                .build();
+        existing = ingredientRepository.save(existing);
+
+        IngredientDto dto1 = IngredientDto.builder()
+                .name("양파")
+                .amount("3")
+                .unit("개")
+                .build();
+        IngredientDto dto2 = IngredientDto.builder()
+                .name("당근")
+                .amount("1")
+                .unit("개")
+                .build();
+        AddRequestDto request = AddRequestDto.builder()
+                .userId(savedUser.getId())
+                .ingredientList(List.of(dto1, dto2))
+                .build();
+
+        userIngredientService.addIngredient(request);
+
+        List<Ingredient> ingredients = ingredientRepository.findAll();
+        assertThat(ingredients).hasSize(2);
+
+        List<UserIngredient> userIngredients = userIngredientRepository.findAll();
+        assertThat(userIngredients).hasSize(2);
+        assertThat(userIngredients)
+                .extracting(ui -> ui.getIngredient().getName())
+                .containsExactlyInAnyOrder("양파", "당근");
+        assertThat(userIngredients)
+                .extracting(UserIngredient::getAmount)
+                .containsExactlyInAnyOrder("3", "1");
+        assertThat(userIngredients)
+                .extracting(UserIngredient::getUnit)
+                .containsExactlyInAnyOrder("개", "개");
+    }
+}


### PR DESCRIPTION
#4 사용자로부터 등록 할 재료의 이름, 수량, 단위를 요청 받아 사용자의 재료를 등록하는 기능

만약 재료 테이블에 존재하지 않는 데이터가 요청 된 경우 임시 유통 기한을 7일하여 재료테이블에 생성

요청 JSON
`{
  "userId": 1,
  "ingredientList": [
    {
      "name": "양파",
      "amount": "3",
      "unit": "개"
    },
    {
      "name": "감자",
      "amount": "500",
      "unit": "g"
    }
  ]
}`